### PR TITLE
Prevent placeholder text from spilling out of input

### DIFF
--- a/ios-placeholder.jquery.js
+++ b/ios-placeholder.jquery.js
@@ -11,7 +11,7 @@
           // Init placeholder div
           placeholderText = $this.attr('placeholder'),
           $placeholder = $('<div class="placeholder">')
-            .css({ position: 'absolute', paddingLeft: (($this.outerHeight() - $this.height()) / 2) + 2 + "px" })
+            .css({ position: 'absolute', paddingLeft: (($this.outerHeight() - $this.height()) / 2) + 2 + "px", width: $this.width(), whiteSpace: 'nowrap', overflow: 'hidden' })
             .text(placeholderText)
             
             // Trigger text field focus


### PR DESCRIPTION
set the placeholder width to match it's input's width and set white-space:nowrap and overflow:hidden so that the label doesn't spill out of the input if the text is too long
